### PR TITLE
Add level unlock codes

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
   <script src="lib/quintus_audio.js"></script>
 
   <script src="js/game.js"></script>
+  <script src="js/levelcodes.js"></script>
   <script src="js/nugget.js"></script>
   <script src="js/defaultenemy.js"></script>
   <script src="js/tangledyarn.js"></script>

--- a/js/endgame.js
+++ b/js/endgame.js
@@ -9,30 +9,34 @@ function loadEndGame(Q) {
         var isWin = stage.options.label === 'You Win';
         
         // Update progress if won
+        var levelCode;
         if (isWin) {
             var progress = Q.state.get('progress') || {
                 unlockedLevels: 1,
                 completedLevels: []
             };
-            
+
             var currentLevel = Q.state.get('currentLevel') || 1;
-            
+
             // Mark level as completed
             if (progress.completedLevels.indexOf(currentLevel) === -1) {
                 progress.completedLevels.push(currentLevel);
             }
-            
+
             // Unlock next level
             if (currentLevel >= progress.unlockedLevels && currentLevel < 8) {
                 progress.unlockedLevels = currentLevel + 1;
             }
-            
+
             Q.state.set('progress', progress);
-            
+
             // Save to localStorage if available
             if (typeof(Storage) !== "undefined") {
                 localStorage.setItem('ydtProgress', JSON.stringify(progress));
             }
+
+            // Generate level code for the newly unlocked level
+            levelCode = encodeLevelCode(progress.unlockedLevels);
         }
 
         var button = container.insert(new Q.UI.Button({
@@ -57,6 +61,21 @@ function loadEndGame(Q) {
             y: -10 - button.p.h,
             label: stage.options.label
         }));
+
+        // Show level code when player wins
+        if (isWin && levelCode) {
+            var codeLabel = container.insert(new Q.UI.Text({
+                x: 10,
+                y: button.p.h + 20,
+                label: 'Code: ' + levelCode,
+                color: '#FFFFFF'
+            }));
+
+            // Remove the code after a few seconds
+            setTimeout(function() {
+                codeLabel.destroy();
+            }, 5000);
+        }
 
         container.fit(20);
     });

--- a/js/levelcodes.js
+++ b/js/levelcodes.js
@@ -1,0 +1,14 @@
+function encodeLevelCode(level) {
+  var num = level * 7 + 13;
+  return num.toString(36).toUpperCase();
+}
+
+function decodeLevelCode(code) {
+  var num = parseInt(code, 36);
+  if (isNaN(num)) return null;
+  var level = (num - 13) / 7;
+  if (level > 0 && Math.floor(level) === level) {
+    return level;
+  }
+  return null;
+}

--- a/js/worldmap.js
+++ b/js/worldmap.js
@@ -220,6 +220,40 @@ function loadWorldMap(Q) {
             size: 14,
             color: '#000'
         }));
+
+        // Button to enter a level code
+        var codeButton = stage.insert(new Q.UI.Button({
+            label: 'Enter Code',
+            x: Q.width - 60,
+            y: 30,
+            fill: '#FFFFFF'
+        }));
+
+        codeButton.on('click', function() {
+            var code = prompt('Enter level code:');
+            if (!code) { return; }
+            var level = decodeLevelCode(code.trim());
+            if (level) {
+                var progress = Q.state.get('progress') || { unlockedLevels: 1, completedLevels: [] };
+                if (level > progress.unlockedLevels) {
+                    progress.unlockedLevels = level;
+                }
+                // Mark previous levels as completed
+                progress.completedLevels = [];
+                for (var i = 1; i < level; i++) {
+                    progress.completedLevels.push(i);
+                }
+                Q.state.set('progress', progress);
+                if (typeof(Storage) !== 'undefined') {
+                    localStorage.setItem('ydtProgress', JSON.stringify(progress));
+                }
+                alert('Unlocked up to level ' + level + '!');
+                Q.clearStages();
+                Q.stageScene('worldMap');
+            } else {
+                alert('Invalid code');
+            }
+        });
         
         // Viewport follows player
         stage.add('viewport').follow(player, {x: true, y: false}, {


### PR DESCRIPTION
## Summary
- add `levelcodes.js` for code encoding/decoding
- display level code in endgame screen
- allow entering a level code from the world map
- load new script in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68505b4ed12483248b4d7cf93b6155c0