### PR TITLE
Enable levels 2-8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,3 +141,17 @@ The game implements a viewport that follows the player (nugget) with the followi
 - **js/yarnball.js**: Collectible implementation
 - **lib/quintus_tmx.js**: Handles loading and processing of TMX files
 - **lib/quintus_2d.js**: Provides 2D game engine functionality 
+
+## Adding New Levels
+
+The game recognizes multiple stages, each defined as `levelN.tmx` in the `data/` directory with a matching loader file `js/levelN.js`.
+
+To introduce a new level:
+
+1. Create a Tiled map named `levelN.tmx` and save it under `data/`.
+2. Copy `js/level1.js` to `js/levelN.js` and update the `Q.stageTMX` call to reference `levelN.tmx`.
+3. Include `<script src="js/levelN.js"></script>` in `index.html`.
+4. Call `loadLevelN(Q);` inside `js/game.js` during setup.
+5. Add `levelN.tmx` to the preload list within `Q.loadTMX` in `js/game.js`.
+
+Following this convention keeps all levels consistent with the existing camera and HUD setup.

--- a/index.html
+++ b/index.html
@@ -116,6 +116,13 @@
   <script src="js/maintitle.js"></script>
   <script src="js/worldmap.js"></script>
   <script src="js/level1.js"></script>
+  <script src="js/level2.js"></script>
+  <script src="js/level3.js"></script>
+  <script src="js/level4.js"></script>
+  <script src="js/level5.js"></script>
+  <script src="js/level6.js"></script>
+  <script src="js/level7.js"></script>
+  <script src="js/level8.js"></script>
   <script src="js/hub.js"></script>
 
   <!-- Input handling -->

--- a/js/game.js
+++ b/js/game.js
@@ -39,6 +39,13 @@ window.addEventListener('load', function() {
     loadHUB(Q);
     loadWorldMap(Q);
     loadLevel1(Q);
+    loadLevel2(Q);
+    loadLevel3(Q);
+    loadLevel4(Q);
+    loadLevel5(Q);
+    loadLevel6(Q);
+    loadLevel7(Q);
+    loadLevel8(Q);
     
     /**
      * Load saved progress from localStorage
@@ -65,7 +72,7 @@ window.addEventListener('load', function() {
     /**
      * We load the files we need for the game.
      */
-    Q.loadTMX('level.tmx, mainTitle.png, nugget_small.png, nugget_small.json, tangledyarn.png, tangledyarn.json, cat.png, cat.json, princess.png, yarnball.png, yarnball.json, music_main.mp3, music_main.ogg, music_die.mp3, music_die.ogg, music_level_complete.mp3, music_level_complete.ogg, yarnball.mp3, yarnball.ogg', function() {
+    Q.loadTMX('level.tmx, level2.tmx, level3.tmx, level4.tmx, level5.tmx, level6.tmx, level7.tmx, level8.tmx, mainTitle.png, nugget_small.png, nugget_small.json, tangledyarn.png, tangledyarn.json, cat.png, cat.json, princess.png, yarnball.png, yarnball.json, music_main.mp3, music_main.ogg, music_die.mp3, music_die.ogg, music_level_complete.mp3, music_level_complete.ogg, yarnball.mp3, yarnball.ogg', function() {
         Q.compileSheets('nugget_small.png', 'nugget_small.json');
         Q.compileSheets('tangledyarn.png', 'tangledyarn.json');
         Q.compileSheets('cat.png', 'cat.json');

--- a/js/level2.js
+++ b/js/level2.js
@@ -1,0 +1,59 @@
+function loadLevel2(Q) {
+    /**
+     * Scene representing level 2.
+     */
+    Q.scene('level2', function(stage) {
+        // Store reference to nugget for camera following
+        var nugget = null;
+        
+        // Override the stage's insert method to capture nugget when it's created
+        var originalInsert = stage.insert;
+        stage.insert = function(obj) {
+            var result = originalInsert.call(this, obj);
+            
+            // Check if this is our nugget
+            if(obj.className === 'nugget' || (obj.p && obj.p.Class === 'nugget')) {
+                nugget = obj;
+                console.log("Nugget found and stored!");
+            }
+            
+            return result;
+        };
+        
+        // Load the TMX file - this will create all objects defined in Tiled
+        Q.stageTMX('level2.tmx', stage);
+        
+        // Restore original insert method
+        stage.insert = originalInsert;
+        
+        // Set up camera to follow nugget if found
+        if(nugget) {
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+            console.log("Camera following nugget");
+        } else {
+            console.error("Nugget not found! Creating one at default position.");
+            // Fallback: create nugget manually if not in TMX
+            nugget = stage.insert(new Q.nugget({ x: 150, y: 380 }));
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+        }
+        
+        // Load the HUD
+        Q.stageScene('HUB', 1);
+        
+        // Start the music
+        Q.audio.stop(); // Stop all current sounds
+        Q.audio.play('music_main.mp3', { loop: true });
+    });
+}

--- a/js/level3.js
+++ b/js/level3.js
@@ -1,0 +1,59 @@
+function loadLevel3(Q) {
+    /**
+     * Scene representing level 3.
+     */
+    Q.scene('level3', function(stage) {
+        // Store reference to nugget for camera following
+        var nugget = null;
+        
+        // Override the stage's insert method to capture nugget when it's created
+        var originalInsert = stage.insert;
+        stage.insert = function(obj) {
+            var result = originalInsert.call(this, obj);
+            
+            // Check if this is our nugget
+            if(obj.className === 'nugget' || (obj.p && obj.p.Class === 'nugget')) {
+                nugget = obj;
+                console.log("Nugget found and stored!");
+            }
+            
+            return result;
+        };
+        
+        // Load the TMX file - this will create all objects defined in Tiled
+        Q.stageTMX('level3.tmx', stage);
+        
+        // Restore original insert method
+        stage.insert = originalInsert;
+        
+        // Set up camera to follow nugget if found
+        if(nugget) {
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+            console.log("Camera following nugget");
+        } else {
+            console.error("Nugget not found! Creating one at default position.");
+            // Fallback: create nugget manually if not in TMX
+            nugget = stage.insert(new Q.nugget({ x: 150, y: 380 }));
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+        }
+        
+        // Load the HUD
+        Q.stageScene('HUB', 1);
+        
+        // Start the music
+        Q.audio.stop(); // Stop all current sounds
+        Q.audio.play('music_main.mp3', { loop: true });
+    });
+}

--- a/js/level4.js
+++ b/js/level4.js
@@ -1,0 +1,59 @@
+function loadLevel4(Q) {
+    /**
+     * Scene representing level 4.
+     */
+    Q.scene('level4', function(stage) {
+        // Store reference to nugget for camera following
+        var nugget = null;
+        
+        // Override the stage's insert method to capture nugget when it's created
+        var originalInsert = stage.insert;
+        stage.insert = function(obj) {
+            var result = originalInsert.call(this, obj);
+            
+            // Check if this is our nugget
+            if(obj.className === 'nugget' || (obj.p && obj.p.Class === 'nugget')) {
+                nugget = obj;
+                console.log("Nugget found and stored!");
+            }
+            
+            return result;
+        };
+        
+        // Load the TMX file - this will create all objects defined in Tiled
+        Q.stageTMX('level4.tmx', stage);
+        
+        // Restore original insert method
+        stage.insert = originalInsert;
+        
+        // Set up camera to follow nugget if found
+        if(nugget) {
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+            console.log("Camera following nugget");
+        } else {
+            console.error("Nugget not found! Creating one at default position.");
+            // Fallback: create nugget manually if not in TMX
+            nugget = stage.insert(new Q.nugget({ x: 150, y: 380 }));
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+        }
+        
+        // Load the HUD
+        Q.stageScene('HUB', 1);
+        
+        // Start the music
+        Q.audio.stop(); // Stop all current sounds
+        Q.audio.play('music_main.mp3', { loop: true });
+    });
+}

--- a/js/level5.js
+++ b/js/level5.js
@@ -1,0 +1,59 @@
+function loadLevel5(Q) {
+    /**
+     * Scene representing level 5.
+     */
+    Q.scene('level5', function(stage) {
+        // Store reference to nugget for camera following
+        var nugget = null;
+        
+        // Override the stage's insert method to capture nugget when it's created
+        var originalInsert = stage.insert;
+        stage.insert = function(obj) {
+            var result = originalInsert.call(this, obj);
+            
+            // Check if this is our nugget
+            if(obj.className === 'nugget' || (obj.p && obj.p.Class === 'nugget')) {
+                nugget = obj;
+                console.log("Nugget found and stored!");
+            }
+            
+            return result;
+        };
+        
+        // Load the TMX file - this will create all objects defined in Tiled
+        Q.stageTMX('level5.tmx', stage);
+        
+        // Restore original insert method
+        stage.insert = originalInsert;
+        
+        // Set up camera to follow nugget if found
+        if(nugget) {
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+            console.log("Camera following nugget");
+        } else {
+            console.error("Nugget not found! Creating one at default position.");
+            // Fallback: create nugget manually if not in TMX
+            nugget = stage.insert(new Q.nugget({ x: 150, y: 380 }));
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+        }
+        
+        // Load the HUD
+        Q.stageScene('HUB', 1);
+        
+        // Start the music
+        Q.audio.stop(); // Stop all current sounds
+        Q.audio.play('music_main.mp3', { loop: true });
+    });
+}

--- a/js/level6.js
+++ b/js/level6.js
@@ -1,0 +1,59 @@
+function loadLevel6(Q) {
+    /**
+     * Scene representing level 6.
+     */
+    Q.scene('level6', function(stage) {
+        // Store reference to nugget for camera following
+        var nugget = null;
+        
+        // Override the stage's insert method to capture nugget when it's created
+        var originalInsert = stage.insert;
+        stage.insert = function(obj) {
+            var result = originalInsert.call(this, obj);
+            
+            // Check if this is our nugget
+            if(obj.className === 'nugget' || (obj.p && obj.p.Class === 'nugget')) {
+                nugget = obj;
+                console.log("Nugget found and stored!");
+            }
+            
+            return result;
+        };
+        
+        // Load the TMX file - this will create all objects defined in Tiled
+        Q.stageTMX('level6.tmx', stage);
+        
+        // Restore original insert method
+        stage.insert = originalInsert;
+        
+        // Set up camera to follow nugget if found
+        if(nugget) {
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+            console.log("Camera following nugget");
+        } else {
+            console.error("Nugget not found! Creating one at default position.");
+            // Fallback: create nugget manually if not in TMX
+            nugget = stage.insert(new Q.nugget({ x: 150, y: 380 }));
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+        }
+        
+        // Load the HUD
+        Q.stageScene('HUB', 1);
+        
+        // Start the music
+        Q.audio.stop(); // Stop all current sounds
+        Q.audio.play('music_main.mp3', { loop: true });
+    });
+}

--- a/js/level7.js
+++ b/js/level7.js
@@ -1,0 +1,59 @@
+function loadLevel7(Q) {
+    /**
+     * Scene representing level 7.
+     */
+    Q.scene('level7', function(stage) {
+        // Store reference to nugget for camera following
+        var nugget = null;
+        
+        // Override the stage's insert method to capture nugget when it's created
+        var originalInsert = stage.insert;
+        stage.insert = function(obj) {
+            var result = originalInsert.call(this, obj);
+            
+            // Check if this is our nugget
+            if(obj.className === 'nugget' || (obj.p && obj.p.Class === 'nugget')) {
+                nugget = obj;
+                console.log("Nugget found and stored!");
+            }
+            
+            return result;
+        };
+        
+        // Load the TMX file - this will create all objects defined in Tiled
+        Q.stageTMX('level7.tmx', stage);
+        
+        // Restore original insert method
+        stage.insert = originalInsert;
+        
+        // Set up camera to follow nugget if found
+        if(nugget) {
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+            console.log("Camera following nugget");
+        } else {
+            console.error("Nugget not found! Creating one at default position.");
+            // Fallback: create nugget manually if not in TMX
+            nugget = stage.insert(new Q.nugget({ x: 150, y: 380 }));
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+        }
+        
+        // Load the HUD
+        Q.stageScene('HUB', 1);
+        
+        // Start the music
+        Q.audio.stop(); // Stop all current sounds
+        Q.audio.play('music_main.mp3', { loop: true });
+    });
+}

--- a/js/level8.js
+++ b/js/level8.js
@@ -1,0 +1,59 @@
+function loadLevel8(Q) {
+    /**
+     * Scene representing level 8.
+     */
+    Q.scene('level8', function(stage) {
+        // Store reference to nugget for camera following
+        var nugget = null;
+        
+        // Override the stage's insert method to capture nugget when it's created
+        var originalInsert = stage.insert;
+        stage.insert = function(obj) {
+            var result = originalInsert.call(this, obj);
+            
+            // Check if this is our nugget
+            if(obj.className === 'nugget' || (obj.p && obj.p.Class === 'nugget')) {
+                nugget = obj;
+                console.log("Nugget found and stored!");
+            }
+            
+            return result;
+        };
+        
+        // Load the TMX file - this will create all objects defined in Tiled
+        Q.stageTMX('level8.tmx', stage);
+        
+        // Restore original insert method
+        stage.insert = originalInsert;
+        
+        // Set up camera to follow nugget if found
+        if(nugget) {
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+            console.log("Camera following nugget");
+        } else {
+            console.error("Nugget not found! Creating one at default position.");
+            // Fallback: create nugget manually if not in TMX
+            nugget = stage.insert(new Q.nugget({ x: 150, y: 380 }));
+            stage.add('viewport').follow(nugget, {
+                x: true,
+                y: true
+            }, {
+                minY: 120,
+                maxY: 500
+            });
+        }
+        
+        // Load the HUD
+        Q.stageScene('HUB', 1);
+        
+        // Start the music
+        Q.audio.stop(); // Stop all current sounds
+        Q.audio.play('music_main.mp3', { loop: true });
+    });
+}


### PR DESCRIPTION
## Summary
- preload TMX data for levels 2-8
- load the new level scenes in game setup
- add scripts for level2 through level8 in the HTML
- implement level2.js to level8.js scenes
- document how to add new levels

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68505d33dc348324876bacdd14b9cdb9