### PR TITLE
Add scarecrow placeholder to early levels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,11 @@ Example object properties in Tiled:
 - Placed in the "princess" object layer
 - Acts as the level goal
 
+### Scarecrow
+- Class: `scarecrow`
+- Replaces the princess in levels 1-7
+- Shows a placeholder color block if `scarecrow.png` is missing
+
 ### Collectibles (Yarnballs)
 - Class: `yarnball`
 - Placed in the "coins" object layer
@@ -137,6 +142,7 @@ The game implements a viewport that follows the player (nugget) with the followi
 - **js/level1.js**: Handles level loading and setup
 - **js/nugget.js**: Player character implementation
 - **js/princessmabel.js**: Princess Mabel character implementation
+- **js/scarecrow.js**: Scarecrow placeholder character used for levels 1-7
 - **js/tangledyarn.js**: Enemy implementation
 - **js/yarnball.js**: Collectible implementation
 - **lib/quintus_tmx.js**: Handles loading and processing of TMX files

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Super YDT Buddies
+
+This project uses the Quintus engine and features multiple levels loaded from TMX files.
+
+## New Sprite: scarecrow
+
+Levels 1-7 now end with a `scarecrow` character instead of the princess. The scarecrow uses
+`scarecrow.png` if available, but when the image is missing the game falls back to drawing a
+simple colored block. Touching the scarecrow triggers a short look-around animation for Nugget
+before the level completion screen appears and the game returns to the world map.

--- a/data/level.tmx
+++ b/data/level.tmx
@@ -2903,7 +2903,7 @@
  <objectgroup name="princess">
   <object id="5" name="princess" type="princess" x="5253" y="527">
    <properties>
-    <property name="Class" value="princess"/>
+    <property name="Class" value="scarecrow"/>
    </properties>
   </object>
  </objectgroup>

--- a/data/level2.tmx
+++ b/data/level2.tmx
@@ -2903,7 +2903,7 @@
  <objectgroup name="princess">
   <object id="5" name="princess" type="princess" x="5253" y="527">
    <properties>
-    <property name="Class" value="princess"/>
+    <property name="Class" value="scarecrow"/>
    </properties>
   </object>
  </objectgroup>

--- a/data/level3.tmx
+++ b/data/level3.tmx
@@ -2903,7 +2903,7 @@
  <objectgroup name="princess">
   <object id="5" name="princess" type="princess" x="5253" y="527">
    <properties>
-    <property name="Class" value="princess"/>
+    <property name="Class" value="scarecrow"/>
    </properties>
   </object>
  </objectgroup>

--- a/data/level4.tmx
+++ b/data/level4.tmx
@@ -2903,7 +2903,7 @@
  <objectgroup name="princess">
   <object id="5" name="princess" type="princess" x="5253" y="527">
    <properties>
-    <property name="Class" value="princess"/>
+    <property name="Class" value="scarecrow"/>
    </properties>
   </object>
  </objectgroup>

--- a/data/level5.tmx
+++ b/data/level5.tmx
@@ -2903,7 +2903,7 @@
  <objectgroup name="princess">
   <object id="5" name="princess" type="princess" x="5253" y="527">
    <properties>
-    <property name="Class" value="princess"/>
+    <property name="Class" value="scarecrow"/>
    </properties>
   </object>
  </objectgroup>

--- a/data/level6.tmx
+++ b/data/level6.tmx
@@ -2903,7 +2903,7 @@
  <objectgroup name="princess">
   <object id="5" name="princess" type="princess" x="5253" y="527">
    <properties>
-    <property name="Class" value="princess"/>
+    <property name="Class" value="scarecrow"/>
    </properties>
   </object>
  </objectgroup>

--- a/data/level7.tmx
+++ b/data/level7.tmx
@@ -2903,7 +2903,7 @@
  <objectgroup name="princess">
   <object id="5" name="princess" type="princess" x="5253" y="527">
    <properties>
-    <property name="Class" value="princess"/>
+    <property name="Class" value="scarecrow"/>
    </properties>
   </object>
  </objectgroup>

--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
   <script src="js/cat.js"></script>
   <script src="js/princessmabel.js"></script>
   <script src="js/yarnball.js"></script>
+  <script src="js/scarecrow.js"></script>
   <script src="js/endgame.js"></script>
   <script src="js/maintitle.js"></script>
   <script src="js/worldmap.js"></script>

--- a/js/game.js
+++ b/js/game.js
@@ -34,6 +34,7 @@ window.addEventListener('load', function() {
     loadTangledyarn(Q);
     loadCat(Q);
     loadYarnball(Q);
+    loadScarecrow(Q);
     loadEndGame(Q);
     loadMainTitle(Q);
     loadHUB(Q);

--- a/js/nugget.js
+++ b/js/nugget.js
@@ -51,6 +51,7 @@ function loadNugget(Q) {
              */
             this.on('die');
             this.on('win');
+            this.on('scarecrowWin');
         },
         /**
          * nugget dies.
@@ -81,6 +82,47 @@ function loadNugget(Q) {
             Q.audio.stop('music_main.mp3');
             Q.audio.play('music_level_complete.mp3');
             Q.stageScene('endGame', 1, { label: 'You Win' });
+        },
+        scarecrowWin: function() {
+            var self = this;
+            this.p.move = false;
+            Q.audio.stop('music_main.mp3');
+            Q.audio.play('music_level_complete.mp3');
+
+            this.animate({ x: this.p.x + 30 }, 0.5, {
+                callback: function() {
+                    var dirs = ['left', 'right', 'left', 'right'];
+                    var i = 0;
+                    var look = function() {
+                        if(i < dirs.length) {
+                            self.p.direction = dirs[i];
+                            i++;
+                            setTimeout(look, 250);
+                        } else {
+                            var stage = self.stage;
+                            var circle = stage.insert(new Q.Sprite({
+                                x: self.p.x,
+                                y: self.p.y,
+                                radius: 10,
+                                type: Q.SPRITE_NONE
+                            }), 10);
+                            circle.add('tween');
+                            circle.draw = function(ctx) {
+                                ctx.fillStyle = '#000';
+                                ctx.beginPath();
+                                ctx.arc(0, 0, this.p.radius, 0, Math.PI * 2);
+                                ctx.fill();
+                            };
+                            circle.animate({ radius: 1000 }, 1, {
+                                callback: function() {
+                                    Q.stageScene('endGame', 1, { label: 'You Win' });
+                                }
+                            });
+                        }
+                    };
+                    look();
+                }
+            });
         },
         /**
          * Execute a nugget step.

--- a/js/scarecrow.js
+++ b/js/scarecrow.js
@@ -1,0 +1,27 @@
+function loadScarecrow(Q) {
+    Q.Sprite.extend('scarecrow', {
+        init: function(p) {
+            this._super(p, {
+                asset: 'scarecrow.png',
+                sensor: true,
+                w: 32,
+                h: 64,
+                color: '#795548'
+            });
+            this.on('sensor');
+        },
+        draw: function(ctx) {
+            var asset = Q.asset('scarecrow.png');
+            if (asset) {
+                ctx.drawImage(asset, -this.p.cx, -this.p.cy);
+            } else {
+                ctx.fillStyle = this.p.color;
+                ctx.fillRect(-this.p.cx, -this.p.cy, this.p.w, this.p.h);
+            }
+        },
+        sensor: function() {
+            this.p.sensor = false;
+            Q('nugget').trigger('scarecrowWin');
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- introduce `scarecrow` sprite with color fallback
- use scarecrow instead of princess in levels 1-7
- trigger new animation sequence when Nugget touches scarecrow
- load scarecrow class in game and index
- document new sprite

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68506960379083249a9984fff06801bd